### PR TITLE
Allow for PLUGIN_PATH/link.

### DIFF
--- a/commands
+++ b/commands
@@ -15,7 +15,7 @@ if [[ $1 == elasticsearch:* ]]; then
             APP_EXISTS=false
         fi
     fi
-    if [[ ! -d "$PLUGIN_PATH/dokku-link" && ! -d "$PLUGIN_PATH/link"]]; then
+    if [[ (! -d "$PLUGIN_PATH/dokku-link") && (! -d "$PLUGIN_PATH/link") ]]; then
         echo "Link plugin not found... Did you install it from https://github.com/rlaneve/dokku-link?"
         exit 1
     fi


### PR DESCRIPTION
Refers to: https://github.com/jezdez/dokku-elasticsearch-plugin/pull/3. Several plugins depend on the path "link" not "dokku-link". Just enable both.
