### PR TITLE
Add list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Commands
 --------
 ```
 $ dokku help
+     elasticsearch:link                    List all Elasticsearch containers
      elasticsearch:create <app>            Create a Elasticsearch container
      elasticsearch:delete <app>            Delete specified Elasticsearch container
      elasticsearch:info <app>              Display container informations
@@ -44,6 +45,11 @@ $ ssh dokku@server elasticsearch:create foo # Client side
 
 Advanced usage
 --------------
+
+Listing containers:
+```
+dokku elasticsearch:list
+```
 
 Deleting containers:
 ```

--- a/commands
+++ b/commands
@@ -3,16 +3,18 @@ set -e;
 
 # Check if name is specified
 if [[ $1 == elasticsearch:* ]]; then
-    if [[ -z $2 ]]; then
-        echo "You must specify an app name"
-        exit 1
-    else
-        APP="$2"
-        # Check if app exists with the same name
-        if [[ -d "$DOKKU_ROOT/$APP" ]]; then
-            APP_EXISTS=true
+    if [[ "$1" != "elasticsearch:list" ]]; then
+        if [[ -z $2 ]]; then
+            echo "You must specify an app name"
+            exit 1
         else
-            APP_EXISTS=false
+            APP="$2"
+            # Check if app exists with the same name
+            if [[ -d "$DOKKU_ROOT/$APP" ]]; then
+                APP_EXISTS=true
+            else
+                APP_EXISTS=false
+            fi
         fi
     fi
     if [[ ! -d "$PLUGIN_PATH/link" ]]; then
@@ -124,6 +126,10 @@ case "$1" in
     fi
     ;;
 
+  elasticsearch:list)
+    ls -d ${DOKKU_ROOT}/*/${PLUGIN_NAME} | sed "s|${DOKKU_ROOT}/\(.*\)/${PLUGIN_NAME}\$|\1|"
+    ;;
+
   elasticsearch:logs)
     ID=$(docker ps -a | grep "$CONTAINER_NAME" |  awk '{print $1}')
     docker logs $ID | tail -n 100
@@ -131,6 +137,7 @@ case "$1" in
 
   help)
     cat && cat<<EOF
+    elasticsearch:list                                      List all Elasticsearch containers
     elasticsearch:create <app>                              Create a Elasticsearch container
     elasticsearch:delete <app>                              Delete specified Elasticsearch container
     elasticsearch:info <app>                                Display container informations

--- a/commands
+++ b/commands
@@ -67,7 +67,7 @@ case "$1" in
     VOLUME="$HOST_DIR:/var/lib/elasticsearch"
 
     # Launch container
-    docker run -v $VOLUME -name=$CONTAINER_NAME -d jezdez/elasticsearch \
+    docker run -v $VOLUME --name=$CONTAINER_NAME -d jezdez/elasticsearch \
         /usr/local/bin/elasticsearch
 
     # Link to a potential existing app

--- a/commands
+++ b/commands
@@ -16,7 +16,23 @@ if [[ $1 == elasticsearch:* ]]; then
         fi
     fi
     if [[ ! -d "$PLUGIN_PATH/link" ]]; then
-        echo "Link plugin not found... Did you install it from https://github.com/rlaneve/dokku-link?"
+        if [[ -d "$PLUGIN_PATH/dokku-link" ]]; then
+            echo "Found 'dokku-link/' directory but not a 'link/' directory. Did you install/clone dokku-link into the link/ directory instead? If so, please run"
+            echo ""
+            echo "    mv dokku-link link"
+            echo ""
+            echo "to fix it."
+        else
+            echo "Link plugin not found..."
+            echo ""
+            echo "Did you install it from https://github.com/rlaneve/dokku-link?"
+            echo ""
+            echo "Run these commands to install it:"
+            echo ""
+            echo "    cd /${PLUGIN_PATH}"
+            echo "    sudo git clone https://github.com/rlaneve/dokku-link link"
+            echo "    sudo dokku plugins-install"
+        fi
         exit 1
     fi
 


### PR DESCRIPTION
This builds on top of my previous commits.

This commit adds a `elasticsearch:list` command, which lists all apps with Elasticsearch containers.
