### PR TITLE
"upgrade" elasticsearch 1.0 -> 1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Ben Firshman "ben@orchardup.com"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl sudo
 RUN curl http://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add -
-RUN echo "deb http://packages.elasticsearch.org/elasticsearch/1.0/debian stable main" >> /etc/apt/sources.list
+RUN echo "deb http://packages.elasticsearch.org/elasticsearch/1.3/debian stable main" >> /etc/apt/sources.list
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get install -y elasticsearch
 ADD run /usr/local/bin/run
 RUN chmod +x /usr/local/bin/run


### PR DESCRIPTION
Update Dockerfile to use 1.3 package
- `es` seems to come up fine
- have not tested implications with using a data volume formerly used by a 1.0 container